### PR TITLE
Fix multiple files with same name

### DIFF
--- a/desktop-gpgs/src/de/golfgl/gdxgamesvcs/GpgsClient.java
+++ b/desktop-gpgs/src/de/golfgl/gdxgamesvcs/GpgsClient.java
@@ -570,7 +570,15 @@ public class GpgsClient implements IGameServiceClient {
         List<File> files = GApiGateway.drive.files().list().setSpaces("appDataFolder").setQ("name='" + name + "'")
                 .execute().getFiles();
         if (files.size() > 1) {
-            throw new GdxRuntimeException("multiple files with name " + name + " exists.");
+            File snapshotFile = null;
+            for (File file : files) {
+                if (file.getMimeType().equals("application/vnd.google-play-games.snapshot")) {
+                    // Search for snapshot files and choose the first founded one
+                    snapshotFile = file;
+                    break;
+                }
+            }
+            return snapshotFile;
         } else if (files.size() < 1) {
             return null;
         } else {

--- a/desktop-gpgs/src/de/golfgl/gdxgamesvcs/GpgsClient.java
+++ b/desktop-gpgs/src/de/golfgl/gdxgamesvcs/GpgsClient.java
@@ -578,6 +578,10 @@ public class GpgsClient implements IGameServiceClient {
                     break;
                 }
             }
+            if (snapshotFile == null)
+                Gdx.app.error(TAG, "Multiple files with name " + name + " exists. No snapshot file found");
+            else
+                Gdx.app.log(TAG, "Multiple files with name " + name + " exists. Choose snapshot file with ID:  " + snapshotFile.getId());
             return snapshotFile;
         } else if (files.size() < 1) {
             return null;

--- a/desktop-gpgs/src/de/golfgl/gdxgamesvcs/GpgsClient.java
+++ b/desktop-gpgs/src/de/golfgl/gdxgamesvcs/GpgsClient.java
@@ -573,7 +573,7 @@ public class GpgsClient implements IGameServiceClient {
             File snapshotFile = null;
             for (File file : files) {
                 if (file.getMimeType().equals("application/vnd.google-play-games.snapshot")) {
-                    // Search for snapshot files and choose the first founded one
+                    // Search for snapshot files and choose the first found one
                     snapshotFile = file;
                     break;
                 }


### PR DESCRIPTION
In my case, I got only one snapshot file and the others have other mime types.

For the case that more than one snapshot file exist I don't know any solution. `getModifiedTime` and `getCreatedTime` return null, so searching for the newest file is impossible in my opinion.