### PR TITLE
Upgrade to Gradle 6.7.1

### DIFF
--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -25,4 +25,4 @@ jobs:
     - name: Setup Android build environment
       uses: android-actions/setup-android@v2.0.2
     - name: Local install
-      run: ./gradlew clean uploadArchives -PSNAPSHOT=true -PLOCAL=true
+      run: ./gradlew clean publishToMavenLocal

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ After including the dependencies and refreshing, you can use the `NoGameServiceC
 ### Building from source
 To build from source, clone or download this repository, then open it in Android Studio. Perform the following command to compile and upload the library in your local repository:
 
-    gradlew clean uploadArchives -PLOCAL=true
+    gradlew clean publishToMavenLocal
     
 See `build.gradle` file for current version to use in your dependencies.
 

--- a/android-amazongc/build.gradle
+++ b/android-amazongc/build.gradle
@@ -1,25 +1,9 @@
-apply plugin: 'com.android.library'
-
-project.group = 'de.golfgl.gdxgamesvcs'
-
-buildscript {
-    repositories {
-        maven { url 'https://plugins.gradle.org/m2/' }
-        google()
-    }
-
-    dependencies {
-        classpath 'com.android.tools.build:gradle:3.2.0'
-    }
-}
-
 android {
-    compileSdkVersion compileSdk
-    buildToolsVersion "${buildTools}"
+    compileSdkVersion compileSdkVer
 
     defaultConfig {
-        minSdkVersion minSdk
-        targetSdkVersion targetSdk
+        minSdkVersion minSdkVer
+        targetSdkVersion targetSdkVer
     }
 
     sourceSets {
@@ -27,7 +11,6 @@ android {
             manifest.srcFile 'AndroidManifest.xml'
             java.srcDirs = ['src']
             res.srcDirs = ['res']
-
         }
     }
 
@@ -35,15 +18,12 @@ android {
         sourceCompatibility JavaVersion.VERSION_1_7
         targetCompatibility JavaVersion.VERSION_1_7
     }
-
-
 }
 
 dependencies {
-    compile project(":core")
-    compile files('libs/gamecirclesdk.jar')
-    compile files('libs/login-with-amazon-sdk.jar')
-    compile files('libs/AmazonInsights-android-sdk-2.1.26.jar')
+    implementation files('libs/gamecirclesdk.jar')
+    implementation files('libs/login-with-amazon-sdk.jar')
+    implementation files('libs/AmazonInsights-android-sdk-2.1.26.jar')
 }
 
 ext {
@@ -51,4 +31,3 @@ ext {
 }
 
 apply from: '../androidpublish.gradle'
-

--- a/android-gpgs/build.gradle
+++ b/android-gpgs/build.gradle
@@ -1,25 +1,22 @@
-apply plugin: 'com.android.library'
-
-project.group = 'de.golfgl.gdxgamesvcs'
-
 buildscript {
     repositories {
-        maven { url 'https://plugins.gradle.org/m2/' }
         google()
+        gradlePluginPortal()
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.2.0'
+        classpath 'com.google.gms:google-services:4.3.10'
     }
 }
 
+apply plugin: 'com.google.gms.google-services'
+
 android {
-    compileSdkVersion compileSdk
-    buildToolsVersion "${buildTools}"
+    compileSdkVersion compileSdkVer
 
     defaultConfig {
-        minSdkVersion minSdk
-        targetSdkVersion targetSdk
+        minSdkVersion minSdkVer
+        targetSdkVersion targetSdkVer
     }
 
     sourceSets {
@@ -27,7 +24,6 @@ android {
             manifest.srcFile 'AndroidManifest.xml'
             java.srcDirs = ['src']
             res.srcDirs = ['res']
-
         }
     }
 
@@ -35,8 +31,11 @@ android {
         sourceCompatibility JavaVersion.VERSION_1_7
         targetCompatibility JavaVersion.VERSION_1_7
     }
+}
 
-
+dependencies {
+    implementation 'com.google.android.gms:play-services-auth:19.2.0'
+    implementation 'com.google.android.gms:play-services-games:21.0.0'
 }
 
 ext {

--- a/android-gpgs/src/de/golfgl/gdxgamesvcs/GpgsClient.java
+++ b/android-gpgs/src/de/golfgl/gdxgamesvcs/GpgsClient.java
@@ -4,8 +4,9 @@ import android.app.Activity;
 import android.content.Intent;
 import android.os.AsyncTask;
 import android.os.Bundle;
-import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
 import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.backends.android.AndroidApplication;

--- a/android-huawei/build.gradle
+++ b/android-huawei/build.gradle
@@ -1,27 +1,21 @@
-apply plugin: 'com.android.library'
-
-project.group = 'de.golfgl.gdxgamesvcs'
-
 buildscript {
     repositories {
-        maven { url 'https://plugins.gradle.org/m2/' }
         google()
+        gradlePluginPortal()
         maven { url 'https://developer.huawei.com/repo/' }
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.2.0'
         classpath 'com.huawei.agconnect:agcp:1.3.2.301'
     }
 }
 
 android {
-    compileSdkVersion compileSdk
-    buildToolsVersion "${buildTools}"
+    compileSdkVersion compileSdkVer
 
     defaultConfig {
-        minSdkVersion 17
-        targetSdkVersion targetSdk
+        minSdkVersion minSdkVer
+        targetSdkVersion targetSdkVer
     }
 
     sourceSets {
@@ -29,7 +23,6 @@ android {
             manifest.srcFile 'AndroidManifest.xml'
             java.srcDirs = ['src']
             res.srcDirs = ['res']
-
         }
     }
 
@@ -37,15 +30,11 @@ android {
         sourceCompatibility JavaVersion.VERSION_1_7
         targetCompatibility JavaVersion.VERSION_1_7
     }
-
-
 }
 
 dependencies {
-    implementation project(":core")
     implementation 'com.huawei.hms:game:5.0.1.301'
     implementation 'com.huawei.hms:hwid:5.0.1.301'
-    implementation "com.badlogicgames.gdx:gdx-backend-android:$gdxVersion"
 }
 
 ext {

--- a/androidpublish.gradle
+++ b/androidpublish.gradle
@@ -1,4 +1,4 @@
-apply plugin: 'maven'
+apply plugin: 'maven-publish'
 apply plugin: 'signing'
 
 def isLocalBuild() {
@@ -52,95 +52,89 @@ def getVersion() {
     }
 }
 
-
-uploadArchives {
-    repositories {
-        mavenDeployer {
-            beforeDeployment { MavenDeployment deployment -> signing.signPom(deployment) }
-
-            pom.groupId = getGroupId()
-            pom.version = getVersion()
-            pom.artifactId = getArtifactId()
-
-            if (isLocalBuild()) {
-                repository(url: getLocalRepositoryUrl())
-            } else {
-                if (isReleaseBuild()) {
-                    repository(url: getReleaseRepositoryUrl()) {
-                        authentication(userName: getRepositoryUsername(), password: getRepositoryPassword())
-                    }
-                }
-                if (isSnapshotBuild()) {
-                    snapshotRepository(url: getSnapshotRepositoryUrl()) {
-                        authentication(userName: getRepositoryUsername(), password: getRepositoryPassword())
-                    }
-                }
-            }
-
-
-
-
-            pom.project {
-                name 'gdx-gamesvcs'
-                description 'Gameservices APIs for libGDX'
-                url 'https://github.com/MrStahlfelge/gdx-gamesvcs'
-
-                scm {
-                    url 'scm:git@github.com:MrStahlfelge/gdx-gamesvcs.git'
-                    connection 'scm:git@github.com:MrStahlfelge/gdx-gamesvcs.git'
-                    developerConnection 'scm:git@github.com:MrStahlfelge/gdx-gamesvcs.git'
-                }
-
-                licenses {
-                    license {
-                        name 'The Apache Software License, Version 2.0'
-                        url 'http://www.apache.org/licenses/LICENSE-2.0.txt'
-                        distribution 'repo'
-                    }
-                }
-
-                developers {
-                    developer {
-                        id 'MrStahlfelge'
-                        name 'Benjamin Schulte'
-                        email 'lightblocks@golfgl.de'
-                    }
-                }
-            }
-        }
-    }
-}
-
-signing {
-    required { isReleaseBuild() && gradle.taskGraph.hasTask("uploadArchives") }
-    sign configurations.archives
-}
-
-
 task androidJavadocs(type: Javadoc) {
     source = android.sourceSets.main.java.srcDirs
     classpath += project.files(android.getBootClasspath().join(File.pathSeparator))
-    // JDK 1.8 is more strict then 1.7. Have JDK 1.8 behave like 1.7 for javadoc generation
-    if (org.gradle.internal.jvm.Jvm.current().getJavaVersion() == JavaVersion.VERSION_1_8) {
-        options.addStringOption('Xdoclint:none', '-quiet')
-    }
+    options.addStringOption('Xdoclint:none', '-quiet')
 }
 
 task androidJavadocsJar(type: Jar, dependsOn: androidJavadocs) {
-    classifier = 'javadoc'
+    archiveClassifier.set('javadoc')
     from androidJavadocs.destinationDir
 }
 
 task androidSourcesJar(type: Jar) {
-    classifier = 'sources'
-    from android.sourceSets.main.java.sourceFiles
+    archiveClassifier.set('sources')
+    from android.sourceSets.main.java.srcDirs
 }
 
-artifacts {
-    archives androidSourcesJar
-    archives androidJavadocsJar
-}
+afterEvaluate { //For android we need to wrap the publishing inside afterEvaluate
+    publishing {
+        publications {
+            release(MavenPublication) {
+                from components.release
 
-afterEvaluate {
-    androidJavadocs.classpath += project.android.libraryVariants.toList().first().javaCompile.classpath
+                groupId = GROUPID
+                artifactId = ARTIFACTID
+                version = getVersion()
+
+                println 'Publishing artifact: ' + GROUPID + ':' + ARTIFACTID + '-' + getVersion()
+
+                pom {
+                    name = libraryName
+                    description = libraryDescription
+                    url = librarySiteUrl
+
+                    licenses {
+                        license {
+                            name = licenseName
+                            url = licenseUrl
+                        }
+                    }
+
+                    developers {
+                        developer {
+                            id = developerId
+                            name = developerName
+                            email = developerEmail
+                        }
+                    }
+
+                    scm {
+                        url = libraryGitUrl
+                        connection = "scm:$libraryGitUrl"
+                        developerConnection = "scm:$libraryGitUrl"
+                    }
+                }
+            }
+        }
+
+        repositories {
+            if (isReleaseBuild()) {
+                maven {
+                    credentials {
+                        username = getRepositoryUsername()
+                        password = getRepositoryPassword()
+                    }
+
+                    url getReleaseRepositoryUrl()
+                }
+            }
+            if (isSnapshotBuild()) {
+                maven {
+                    credentials {
+                        username = getRepositoryUsername()
+                        password = getRepositoryPassword()
+                    }
+
+                    url getSnapshotRepositoryUrl()
+                }
+            }
+        }
+    }
+
+    signing {
+        required { isReleaseBuild() }
+        sign publishing.publications.release
+    }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -1,17 +1,19 @@
 ext {
     GROUPID = 'de.golfgl.gdxgamesvcs'
     VERSION = '1.1.0'
-
 }
 
 buildscript {
     repositories {
-        maven { url 'https://plugins.gradle.org/m2/' }
+        mavenLocal()
+        mavenCentral()
         google()
+        gradlePluginPortal()
+        maven { url "https://oss.sonatype.org/content/repositories/snapshots/" }
     }
     dependencies {
         classpath 'org.wisepersist:gwt-gradle-plugin:1.0.6'
-        classpath 'com.android.tools.build:gradle:3.2.0'
+        classpath 'com.android.tools.build:gradle:4.2.2'
         classpath 'com.mobidevelop.robovm:robovm-gradle-plugin:2.3.5'
     }
 }
@@ -21,23 +23,34 @@ allprojects {
     apply plugin: "idea"
 
     ext {
-        minSdk = 15
-        targetSdk = 27
-        compileSdk = 27
-        buildTools = '28.0.3'
+        minSdkVer = 16
+        targetSdkVer = 30
+        compileSdkVer = 30
+        buildToolsVer = '30.0.2'
 
-        appName = 'gdx-gamesvcs'
         gdxVersion = '1.9.8'
         roboVMVersion = '2.3.5'
+
+        //Variables used in publishing step
+        libraryName = 'gdx-gamesvcs'
+        libraryDescription = 'Gameservices APIs for libGDX.'
+        librarySiteUrl = 'https://github.com/MrStahlfelge/gdx-gamesvcs'
+        libraryGitUrl = 'git@github.com:MrStahlfelge/gdx-gamesvcs.git'
+        developerId = 'MrStahlfelge'
+        developerName = 'Benjamin Schulte'
+        developerEmail = 'lightblocks@golfgl.de'
+        licenseName = 'The Apache Software License, Version 2.0'
+        licenseUrl = 'http://www.apache.org/licenses/LICENSE-2.0.txt'
+        licenseDistribution = 'repo'
     }
 
     repositories {
-        mavenCentral()
         mavenLocal()
-        maven { url 'https://plugins.gradle.org/m2/' }
+        mavenCentral()
+        google()
+        gradlePluginPortal()
         maven { url "https://oss.sonatype.org/content/repositories/snapshots/" }
         maven { url "https://oss.sonatype.org/content/repositories/releases/" }
-        maven { url "https://maven.google.com" }
         maven { url 'https://developer.huawei.com/repo/' }
     }
 
@@ -46,94 +59,85 @@ allprojects {
 }
 
 project(":android-gpgs") {
-    configurations {
-        custom
-        compile.extendsFrom custom
-    }
+    apply plugin: 'com.android.library'
 
     eclipse {
         project {
-            name = appName + "-android-gpgs"
+            name = "$libraryName-android-gpgs"
         }
     }
 
     dependencies {
-        if (!project.hasProperty('gms_library_version')) {
-            ext.gms_library_version = '16.0.0'
-        }
-
-        compile "com.google.android.gms:play-services-games:${gms_library_version}"
-        compile "com.badlogicgames.gdx:gdx-backend-android:$gdxVersion"
-
-        compile project(':core')
+        implementation project(":core")
+        api "com.badlogicgames.gdx:gdx-backend-android:$gdxVersion"
     }
 }
 
+project(":android-amazongc") {
+    apply plugin: 'com.android.library'
+
+    eclipse {
+        project {
+            name = "$libraryName-android-amazongc"
+        }
+    }
+
+    dependencies {
+        implementation project(":core")
+        api "com.badlogicgames.gdx:gdx-backend-android:$gdxVersion"
+    }
+}
+
+project(":android-huawei") {
+    apply plugin: 'com.android.library'
+
+    eclipse {
+        project {
+            name = "$libraryName-android-huawei"
+        }
+    }
+
+    dependencies {
+        implementation project(":core")
+        api "com.badlogicgames.gdx:gdx-backend-android:$gdxVersion"
+    }
+}
 
 project(":core") {
-    apply plugin: 'java'
-
-    apply from: '../publish.gradle'
-
-    configurations {
-        custom
-        compile.extendsFrom custom
-    }
+    apply plugin: 'java-library'
 
     eclipse {
         project {
-            name = appName + "-core"
+            name = "$libraryName-core"
         }
     }
 
     dependencies {
-        compile "com.badlogicgames.gdx:gdx:$gdxVersion"
+        api "com.badlogicgames.gdx:gdx:$gdxVersion"
     }
 }
-
-
-
 
 project(":core-gamejolt") {
     apply plugin: 'java'
 
-    apply from: '../publish.gradle'
-
-    configurations {
-        custom
-        compile.extendsFrom custom
-    }
-
     eclipse {
         project {
-            name = appName + "-core-gamejolt"
+             name = "$libraryName-core-gamejolt"
         }
     }
 
     dependencies {
-        compile project(':core')
-    }
-    dependencies {
-        compile "com.badlogicgames.gdx:gdx:$gdxVersion"
+        implementation project(':core')
+        implementation "com.badlogicgames.gdx:gdx:$gdxVersion"
     }
 }
-
-
-
 
 project(":desktop-gpgs") {
     apply plugin: 'java'
 
-    apply from: '../publish.gradle'
-
-    configurations {
-        custom
-        compile.extendsFrom custom
-    }
-
     eclipse {
         project {
-            name = appName + "-desktop-gpgs"
+            name = "$libraryName-desktop-gpgs"
         }
     }
     
@@ -142,100 +146,68 @@ project(":desktop-gpgs") {
     }
 
     dependencies {
-        compile project(':core')
+        implementation project(':core')
+
+        implementation "com.google.apis:google-api-services-games:v1-rev239-$gapiVersion"
+        implementation "com.google.oauth-client:google-oauth-client-jetty:$gapiVersion"
+        implementation "com.google.apis:google-api-services-drive:v3-rev77-$gapiVersion"
         
-        compile "com.google.apis:google-api-services-games:v1-rev239-$gapiVersion"
-        compile "com.google.oauth-client:google-oauth-client-jetty:$gapiVersion"
-        compile "com.google.apis:google-api-services-drive:v3-rev77-$gapiVersion"
-        
-        testCompile "com.badlogicgames.gdx:gdx-backend-lwjgl:$gdxVersion"
-        testCompile "com.badlogicgames.gdx:gdx-platform:$gdxVersion:natives-desktop"
+        testImplementation "com.badlogicgames.gdx:gdx-backend-lwjgl:$gdxVersion"
+        testImplementation "com.badlogicgames.gdx:gdx-platform:$gdxVersion:natives-desktop"
     }
 }
-
 
 project(":html-kong") {
     apply plugin: 'java'
 
-
-    apply from: '../publish.gradle'
-
-    configurations {
-        custom
-        compile.extendsFrom custom
-    }
-
     eclipse {
         project {
-            name = appName + "-html-kong"
+            name = "$libraryName-html-kong"
         }
     }
 
     dependencies {
-        compile project(':core')
-    }
-    dependencies {
-        compile "com.badlogicgames.gdx:gdx-backend-gwt:$gdxVersion"
-        compile "com.badlogicgames.gdx:gdx:$gdxVersion:sources"
-        compile "com.badlogicgames.gdx:gdx-backend-gwt:$gdxVersion:sources"
+        implementation project(':core')
+
+        implementation "com.badlogicgames.gdx:gdx-backend-gwt:$gdxVersion"
+        implementation "com.badlogicgames.gdx:gdx:$gdxVersion:sources"
+        implementation "com.badlogicgames.gdx:gdx-backend-gwt:$gdxVersion:sources"
     }
 }
-
-
 
 project(":html-gpgs") {
     apply plugin: 'java'
 
-
-    apply from: '../publish.gradle'
-
-    configurations {
-        custom
-        compile.extendsFrom custom
-    }
-
     eclipse {
         project {
-            name = appName + "-html-gpgs"
+            name = "$libraryName-html-gpgs"
         }
     }
 
     dependencies {
-        compile project(':core')
-    }
-    dependencies {
-        compile "com.badlogicgames.gdx:gdx-backend-gwt:$gdxVersion"
-        compile "com.badlogicgames.gdx:gdx:$gdxVersion:sources"
-        compile "com.badlogicgames.gdx:gdx-backend-gwt:$gdxVersion:sources"
+        implementation project(':core')
+
+        implementation "com.badlogicgames.gdx:gdx-backend-gwt:$gdxVersion"
+        implementation "com.badlogicgames.gdx:gdx:$gdxVersion:sources"
+        implementation "com.badlogicgames.gdx:gdx-backend-gwt:$gdxVersion:sources"
     }
 }
-
-
 
 project(":ios-gamecenter") {
     apply plugin: 'java'
     apply plugin: 'robovm'
 
-    apply from: '../publish.gradle'
-
-    configurations {
-        custom
-        compile.extendsFrom custom
-    }
-
     eclipse {
         project {
-            name = appName + "-ios-gamecenter"
+            name = "$libraryName-html-gpgs"
         }
     }
 
     dependencies {
+        implementation project(':core')
 
-        compile project(':core')
-
-        compile "com.mobidevelop.robovm:robovm-rt:${roboVMVersion}"
-        compile "com.mobidevelop.robovm:robovm-cocoatouch:${roboVMVersion}"
-        compile "com.badlogicgames.gdx:gdx-backend-robovm:$gdxVersion"
-
+        implementation "com.badlogicgames.gdx:gdx-backend-robovm:$gdxVersion"
+        implementation "com.mobidevelop.robovm:robovm-rt:$roboVMVersion"
+        implementation "com.mobidevelop.robovm:robovm-cocoatouch:$roboVMVersion"
     }
 }

--- a/core-gamejolt/build.gradle
+++ b/core-gamejolt/build.gradle
@@ -1,8 +1,10 @@
-targetCompatibility = 1.7
-sourceCompatibility = 1.7
+targetCompatibility = JavaVersion.VERSION_1_7
+sourceCompatibility = JavaVersion.VERSION_1_7
 
 sourceSets.main.java.srcDirs = [ "src/" ]
 
 ext {
 	ARTIFACTID = 'gdx-gamesvcs-core-gamejolt'
-}		
+}
+
+apply from: '../publish.gradle'

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -1,15 +1,15 @@
 apply plugin : 'java'
 
-targetCompatibility = 1.7
-sourceCompatibility = 1.7
+sourceCompatibility = JavaVersion.VERSION_1_7
+targetCompatibility = JavaVersion.VERSION_1_7
 
 [compileJava, compileTestJava]*.options*.encoding = 'UTF-8'
 
 sourceSets.main.java.srcDirs = [ "src/" ]
 sourceSets.test.java.srcDirs = [ "test/" ]
 
-
 ext {
 	ARTIFACTID = 'gdx-gamesvcs-core'
 }
 
+apply from: '../publish.gradle'

--- a/desktop-gpgs/build.gradle
+++ b/desktop-gpgs/build.gradle
@@ -1,5 +1,5 @@
-targetCompatibility = 1.7
-sourceCompatibility = 1.7
+targetCompatibility = JavaVersion.VERSION_1_7
+sourceCompatibility = JavaVersion.VERSION_1_7
 
 sourceSets.main.java.srcDirs = [ "src/" ]
 sourceSets.test.java.srcDirs = [ "test/", "test-resources/" ]
@@ -7,3 +7,5 @@ sourceSets.test.java.srcDirs = [ "test/", "test-resources/" ]
 ext {
 	ARTIFACTID = 'gdx-gamesvcs-desktop-gpgs'
 }
+
+apply from: '../publish.gradle'

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,4 @@
 org.gradle.daemon=true
 org.gradle.jvmargs=-Xms1024m -Xmx2048m
 org.gradle.configureondemand=true
+android.useAndroidX=true

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.6-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.7.1-all.zip

--- a/html-gpgs/build.gradle
+++ b/html-gpgs/build.gradle
@@ -1,8 +1,10 @@
-targetCompatibility = 1.7
-sourceCompatibility = 1.7
+targetCompatibility = JavaVersion.VERSION_1_7
+sourceCompatibility = JavaVersion.VERSION_1_7
 
 sourceSets.main.java.srcDirs = [ "src/" ]
 
 ext {
 	ARTIFACTID = 'gdx-gamesvcs-html-gpgs'
-}		
+}
+
+apply from: '../publish.gradle'

--- a/html-kong/build.gradle
+++ b/html-kong/build.gradle
@@ -1,8 +1,10 @@
-targetCompatibility = 1.7
-sourceCompatibility = 1.7
+targetCompatibility = JavaVersion.VERSION_1_7
+sourceCompatibility = JavaVersion.VERSION_1_7
 
 sourceSets.main.java.srcDirs = [ "src/" ]
 
 ext {
 	ARTIFACTID = 'gdx-gamesvcs-html-kong'
-}		
+}
+
+apply from: '../publish.gradle'

--- a/ios-gamecenter/build.gradle
+++ b/ios-gamecenter/build.gradle
@@ -1,9 +1,10 @@
-targetCompatibility = 1.7
-sourceCompatibility = 1.7
+targetCompatibility = JavaVersion.VERSION_1_7
+sourceCompatibility = JavaVersion.VERSION_1_7
 
 sourceSets.main.java.srcDirs = [ "src/" ]
 
-
 ext {
 	ARTIFACTID = 'gdx-gamesvcs-ios-gamecenter'
-}	
+}
+
+apply from: '../publish.gradle'

--- a/publish.gradle
+++ b/publish.gradle
@@ -1,4 +1,4 @@
-apply plugin: 'maven'
+apply plugin: 'maven-publish'
 apply plugin: 'signing'
 
 def isLocalBuild() {
@@ -52,91 +52,76 @@ def getVersion() {
     }
 }
 
-afterEvaluate { project ->
-    uploadArchives {
-        repositories {
-            mavenDeployer {
-                beforeDeployment { MavenDeployment deployment -> signing.signPom(deployment) }
+java {
+    withJavadocJar()
+    withSourcesJar()
+}
 
-                pom.groupId = getGroupId()
-                pom.version = getVersion()
-				pom.artifactId = getArtifactId()
+publishing {
+    publications {
+        mavenJava(MavenPublication) {
+            from components.java
 
+            groupId = GROUPID
+            artifactId = ARTIFACTID
+            version = getVersion()
 
-                if (isLocalBuild()) {
-                    repository(url: getLocalRepositoryUrl())
-                } else {
-                    if (isReleaseBuild()) {
-                        repository(url: getReleaseRepositoryUrl()) {
-                            authentication(userName: getRepositoryUsername(), password: getRepositoryPassword())
-                        }
-                    }
-                    if (isSnapshotBuild()) {
-                        snapshotRepository(url: getSnapshotRepositoryUrl()) {
-                            authentication(userName: getRepositoryUsername(), password: getRepositoryPassword())
-                        }
+            println 'Publishing artifact: ' + GROUPID + ':' + ARTIFACTID + '-' + getVersion()
+
+            pom {
+                name = libraryName
+                description = libraryDescription
+                url = librarySiteUrl
+
+                licenses {
+                    license {
+                        name = licenseName
+                        url = licenseUrl
                     }
                 }
 
-
-
-
-                pom.project {
-                    name 'gdx-gamesvcs'
-                    description 'Gameservices APIs for libGDX'
-                    url 'https://github.com/MrStahlfelge/gdx-gamesvcs'
-
-                    scm {
-                        url 'scm:git@github.com:MrStahlfelge/gdx-gamesvcs.git'
-                        connection 'scm:git@github.com:MrStahlfelge/gdx-gamesvcs.git'
-                        developerConnection 'scm:git@github.com:MrStahlfelge/gdx-gamesvcs.git'
+                developers {
+                    developer {
+                        id = developerId
+                        name = developerName
+                        email = developerEmail
                     }
+                }
 
-                    licenses {
-                        license {
-                            name 'The Apache Software License, Version 2.0'
-                            url 'http://www.apache.org/licenses/LICENSE-2.0.txt'
-                            distribution 'repo'
-                        }
-                    }
-
-                    developers {
-                        developer {
-                            id 'MrStahlfelge'
-                            name 'Benjamin Schulte'
-                            email 'lightblocks@golfgl.de'
-                        }
-                    }
+                scm {
+                    url = libraryGitUrl
+                    connection = "scm:$libraryGitUrl"
+                    developerConnection = "scm:$libraryGitUrl"
                 }
             }
         }
     }
 
+    repositories {
+        if (isReleaseBuild()) {
+            maven {
+                credentials {
+                    username = getRepositoryUsername()
+                    password = getRepositoryPassword()
+                }
+
+                url getReleaseRepositoryUrl()
+            }
+        }
+        if (isSnapshotBuild()) {
+            maven {
+                credentials {
+                    username = getRepositoryUsername()
+                    password = getRepositoryPassword()
+                }
+
+                url getSnapshotRepositoryUrl()
+            }
+        }
+    }
+
     signing {
-        required { isReleaseBuild() && gradle.taskGraph.hasTask("uploadArchives") }
-        sign configurations.archives
+        required { isReleaseBuild() }
+        sign publishing.publications.mavenJava
     }
-
-    task libraryJar(type: Jar, dependsOn:classes) {
-        from sourceSets.main.output.classesDir
-        from configurations.custom.collect { it.isDirectory() ? it : zipTree(it) }
-        classifier = 'library'
-    }
-
-    task sourcesJar(type: Jar, dependsOn:classes) {
-        from sourceSets.main.allSource
-        classifier = 'sources'
-    }
-
-    task javadocJar(type: Jar, dependsOn:javadoc) {
-        from javadoc.destinationDir
-        classifier = 'javadoc'
-    }
-
-    artifacts {
-        archives libraryJar
-        archives sourcesJar
-        archives javadocJar
-    }
-
 }

--- a/settings.gradle
+++ b/settings.gradle
@@ -7,4 +7,3 @@ include ':desktop-gpgs'
 include ':html-gpgs'
 include ':html-kong'
 include ':ios-gamecenter'
-


### PR DESCRIPTION
Hello,

I've been working on refactoring the android-gpgs implementation because it uses deprecated Google APIs. However, when building the project I noticed that the project is based on an older Gradle version. I figured I'd migrate the project to Gradle 7.0.3 before proceeding with the actual refactoring.

Here is a PR that contains the needed changes to build / deploy the project with Gradle 7. Basically all of the gradle scripts needed some tuning to get this to work.

Building with `gradlew clean publishToMavenLocal` on Windows or `gradle clean publishToMavenLocal` on Linux works great and the local repository populates with libraries I can use in my project. 

Obviously I haven't tested deploying the package to the external repository but thats something maybe you, the developer, can test.

If you need me to do any additional fixes or other changes please let me know. 