### PR TITLE
Change fetchLeaderboardEntriesSync to public

### DIFF
--- a/android-gpgs/src/de/golfgl/gdxgamesvcs/GpgsClient.java
+++ b/android-gpgs/src/de/golfgl/gdxgamesvcs/GpgsClient.java
@@ -463,8 +463,8 @@ public class GpgsClient implements GoogleApiClient.ConnectionCallbacks, GoogleAp
         return true;
     }
 
-    private boolean fetchLeaderboardEntriesSync(String leaderBoardId, int limit, boolean relatedToPlayer,
-                                                IFetchLeaderBoardEntriesResponseListener callback) {
+    public boolean fetchLeaderboardEntriesSync(String leaderBoardId, int limit, boolean relatedToPlayer,
+                                               IFetchLeaderBoardEntriesResponseListener callback) {
         if (!isSessionActive())
             return false;
 


### PR DESCRIPTION
Hello!
In my game I fetch several leaderboards entries at once and I want to fetch them one by one sync. Once they are fetched, I show the relevant UI for all of them at once.
I saw only the async is public and the sync in private, so I wonder if this could be merged.
Thanks in advance